### PR TITLE
Poprawki do kamery

### DIFF
--- a/skater/camera.py
+++ b/skater/camera.py
@@ -1,18 +1,17 @@
 
 class Camera:
+    LAG = 0.01
+
     def __init__(self):
         self.x = 0
         self.y = 0        
 
     def adjust(self, screen, player):
-        
-        LAG = 0.01
-
-        self.adjust_x(screen, player, LAG)
-        self.adjust_y(screen, player, LAG)
+        self.adjust_x(screen.get_rect(), player.rect)
+        self.adjust_y(screen.get_rect(), player.rect)
 
 
-    def adjust_x(self, screen, player, lag):
+    def adjust_x(self, screen_rect, player_rect):
         """
         Computes the required camera adjustment depending on player's location and camera's current x shift
         """
@@ -20,41 +19,41 @@ class Camera:
         margin_right = 0.3
 
         # point when camera should move down / up dependent on player's vertical position on the screen
-        cam_thresh_left = margin_left * screen.get_rect().width
-        cam_thresh_right = margin_right * screen.get_rect().width
+        cam_thresh_left = margin_left * screen_rect.width
+        cam_thresh_right = margin_right * screen_rect.width
 
         # compute camera / player coordinates on the screen
-        player_position = player.rect.x + player.rect.width / 2
-        camera_focus = self.x + screen.get_rect().width / 2
+        player_position = player_rect.x + player_rect.width / 2
+        camera_focus = self.x + screen_rect.width / 2
 
         relative_player_position = player_position - camera_focus
 
         if relative_player_position > cam_thresh_right or relative_player_position < -1 * cam_thresh_left:
             # player is outside of camera's focus -> move camera
-            self.x += relative_player_position * lag
+            self.x += relative_player_position * self.LAG
 
         else:
             # player is within camera's focus -> do nothing
             pass
 
-    def adjust_y(self, screen, player, lag):
+    def adjust_y(self, screen_rect, player_rect):
             """
             see `adjust_x`
             """
             margin_top = 0.3
             margin_bottom = 0.5
 
-            cam_thresh_top = margin_top * screen.get_rect().height
-            cam_thresh_bottom = margin_bottom * screen.get_rect().height
+            cam_thresh_top = margin_top * screen_rect.height
+            cam_thresh_bottom = margin_bottom * screen_rect.height
 
-            player_position = player.rect.y + player.rect.height / 2
-            camera_focus = self.y + screen.get_rect().height / 2
+            player_position = player_rect.y + player_rect.height / 2
+            camera_focus = self.y + screen_rect.height / 2
 
             relative_player_position = player_position - camera_focus
 
             if relative_player_position < -1 * cam_thresh_bottom or relative_player_position > cam_thresh_top:
                 # player is outside of camera's focus -> move camera
-                self.y += relative_player_position * lag
+                self.y += relative_player_position * self.LAG
 
             else:
                 # player is within camera's focus -> do nothing

--- a/skater/camera.py
+++ b/skater/camera.py
@@ -1,14 +1,12 @@
 
 class Camera:
-
     def __init__(self):
         self.x = 0
-        self.y = 0
-        
+        self.y = 0        
 
     def adjust(self, screen, player):
         
-        LAG = 0.99
+        LAG = 0.01
 
         self.adjust_x(screen, player, LAG)
         self.adjust_y(screen, player, LAG)
@@ -16,49 +14,48 @@ class Camera:
 
     def adjust_x(self, screen, player, lag):
         """
-        Changes camera x parameteres depending on the location of the player on screen x axis
+        Computes the required camera adjustment depending on player's location and camera's current x shift
         """
-        MARGIN_LEFT = 0.2
-        MARGIN_RIGHT = 0.5
+        margin_left = 0.2
+        margin_right = 0.3
 
         # point when camera should move down / up dependent on player's vertical position on the screen
-        cam_thresh_left = screen.get_rect().x + MARGIN_LEFT * screen.get_rect().width
-        cam_thresh_right = screen.get_rect().x + MARGIN_RIGHT * screen.get_rect().width
+        cam_thresh_left = margin_left * screen.get_rect().width
+        cam_thresh_right = margin_right * screen.get_rect().width
 
-        if player.rect.x < cam_thresh_left:
+        # compute camera / player coordinates on the screen
+        player_position = player.rect.x + player.rect.width / 2
+        camera_focus = self.x + screen.get_rect().width / 2
 
-            ##### hey rwa: with this commented code below the game looks a lot less smooth 
-            ##### and distances between obstacles are not correct.
+        relative_player_position = player_position - camera_focus
 
-            #self.x -= abs(player.rect.x - cam_thresh_left) * lag
-            self.x -= 1
-            
-        elif player.rect.x > cam_thresh_right:
-            #self.x += abs(player.rect.x - cam_thresh_right) * lag
-            self.x += 1
+        if relative_player_position > cam_thresh_right or relative_player_position < -1 * cam_thresh_left:
+            # player is outside of camera's focus -> move camera
+            self.x += relative_player_position * lag
 
-        else: 
-            self.x = 0
-
+        else:
+            # player is within camera's focus -> do nothing
+            pass
 
     def adjust_y(self, screen, player, lag):
-        """
-        Changes camera y parameteres depending on the location of the player on screen y axis
-        """
-        MARGIN_TOP = 0.3
-        MARGIN_BOTTOM = 0.6
+            """
+            see `adjust_x`
+            """
+            margin_top = 0.3
+            margin_bottom = 0.5
 
-        # point when camera should move down / up dependent on player's vertical position on the screen
-        cam_thresh_up = screen.get_rect().y + MARGIN_TOP * screen.get_rect().height
-        cam_thresh_down = screen.get_rect().y + MARGIN_BOTTOM * screen.get_rect().height
+            cam_thresh_top = margin_top * screen.get_rect().height
+            cam_thresh_bottom = margin_bottom * screen.get_rect().height
 
-        if player.rect.y < cam_thresh_up:
-            #self.y -= abs(player.rect.y - cam_thresh_up) * lag
-            self.y -= 1
+            player_position = player.rect.y + player.rect.height / 2
+            camera_focus = self.y + screen.get_rect().height / 2
 
-        elif player.rect.y > cam_thresh_down:
-            #self.y += abs(player.rect.y - cam_thresh_down)
-            self.y += 1
+            relative_player_position = player_position - camera_focus
 
-        else: 
-            self.y = 0
+            if relative_player_position < -1 * cam_thresh_bottom or relative_player_position > cam_thresh_top:
+                # player is outside of camera's focus -> move camera
+                self.y += relative_player_position * lag
+
+            else:
+                # player is within camera's focus -> do nothing
+                pass

--- a/skater/game.py
+++ b/skater/game.py
@@ -100,7 +100,7 @@ class Game(State):
         font = pygame.font.SysFont('Arial', 40)
 
         # clean game area
-        screen.fill(WHITE, (0 - self.camera.x, 0, screen.get_size()[0], screen.get_size()[1]))
+        screen.fill(WHITE, (0, 0, screen.get_size()[0], screen.get_size()[1]))
 
         if not self.game_over:
 
@@ -113,13 +113,13 @@ class Game(State):
                 # self.level - 1 because drawing takes place in main after score was increased
                 won_level_text = ["Level " + str(self.level) + " beated!", "Press Y key to continue"]
                 for i, text in enumerate(won_level_text):
-                    draw_text(screen, text, font, BLACK, "L", 500 - self.camera.x, 300 + i * 50)
+                    draw_text(screen, text, font, BLACK, "L", 500, 300 + i * 50)
 
         # Game over screen
         else:
             game_over_text = ["You lost!", "Total score: {}".format(self.score.total_score),  "Do you want to continue? Y/N"]
             for i, text in enumerate(game_over_text):
-                draw_text(screen, text, font, BLACK, "L", 500 - self.camera.x, 300 + i * 50)
+                draw_text(screen, text, font, BLACK, "L", 500, 300 + i * 50)
 
             self.draw_main_game(screen, BLACK)
 
@@ -136,9 +136,6 @@ class Game(State):
 
         # Draw scores in right top corner
         self.draw_game_results(screen, self.score, color)
-
-        # update player image in new position
-        screen.blit(self.player.image, (self.player.rect.x, self.player.rect.y))
   
 
     def draw_ground(self, screen, color):

--- a/skater/obstacles.py
+++ b/skater/obstacles.py
@@ -30,7 +30,7 @@ class Obstacle(pygame.sprite.Sprite):
         """
         Checks if `self` is located over `other_rect`, regardless of the distance
         """
-        return self.rect.bottom <= other_rect.top and self.rect.top < other_rect.top \
+        return self.rect.top <= other_rect.bottom and self.rect.top < other_rect.top \
             and self.rect.left < other_rect.right and self.rect.right > other_rect.left
 
     def is_to_the_right(self, other_rect):

--- a/skater/player.py
+++ b/skater/player.py
@@ -25,7 +25,7 @@ class Player(pygame.sprite.Sprite):
         
         # make collider smaller than the image
         band = 4
-        self.collide_rect = pygame.Rect(self.rect.x + band, self.rect.top, self.rect.width - 2*band, self.rect.height)
+        # self.collide_rect = pygame.Rect(self.rect.x + band, self.rect.top, self.rect.width - 2*band, self.rect.height)
 
         # speed is used for movement to left/right
         self.speed = speed
@@ -69,7 +69,7 @@ class Player(pygame.sprite.Sprite):
         if not self.is_jumping:
 
             # here need to change to also use the dictionary CONTROLS - tbd later
-            if (keystate[K_RIGHT] or keystate[K_d]) and self.rect.x < (screen.get_size()[0] - self.rect.width):
+            if (keystate[K_RIGHT] or keystate[K_d]):# and self.rect.x < (screen.get_size()[0] - self.rect.width):
                 self.moving_direction_x = 1
                 self.speed = self.v0
 
@@ -125,8 +125,7 @@ class Player(pygame.sprite.Sprite):
         # find x position of the closest obstacle edges on the right and left side of the player
         limit_right = min(obstacle.rect.left for obstacle in gameboard.obstacles_right(self))
         limit_left = max(obstacle.rect.right for obstacle in gameboard.obstacles_left(self))
-
-
+        
         # stop movement if collision on the right of the player takes place
         if self.moving_direction_x > 0 and self.rect.right > limit_right:
             self.stop_movement_x(limit_right - self.rect.width)

--- a/skater/render_functions.py
+++ b/skater/render_functions.py
@@ -11,9 +11,5 @@ def draw_text(screen, text, font, color, side, side_px, top_px):
 
 def draw_sprite(screen, sprite, camera):
 
-    # draw sprite on screen dependent on camera position
-    sprite_rect = sprite.rect
-    sprite_rect.x -= camera.x
-    sprite_rect.y -= camera.y
-
-    screen.blit(sprite.image, sprite_rect)
+    rendering_position = (sprite.rect.x - camera.x, sprite.rect.y - camera.y)
+    screen.blit(sprite.image, rendering_position)

--- a/tests/mock_rect.py
+++ b/tests/mock_rect.py
@@ -1,0 +1,42 @@
+class MockRect:
+    """
+    A mock replacement of `pygame.sprite.Sprite.rect` for testing purposes
+    """
+    def __init__(self, top, bottom, left, right):
+        self.top = top
+        self.bottom = bottom
+        self.left = left
+        self.right = right
+
+    @property
+    def x(self):
+        return self.left
+
+    @property 
+    def y(self):
+        return self.top
+
+    @property
+    def width(self):
+        return (self.right - self.left)
+
+    @property
+    def height(self):
+        return (self.bottom - self.top)
+
+# Utility methods to make tests more readable
+def makeMockRect(other_rectangle):
+    return MockRect(
+        other_rectangle.top,
+        other_rectangle.bottom,
+        other_rectangle.left,
+        other_rectangle.right
+    )
+
+def shifted(base_rect, x_shift=0, y_shift=0):
+    return MockRect(
+        base_rect.top + y_shift,
+        base_rect.bottom + y_shift,
+        base_rect.left + x_shift,
+        base_rect.right + x_shift
+    )

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+
+from skater.camera import Camera
+
+from .mock_rect import MockRect, shifted
+
+screen_width = 400
+screen_height = 300
+screen_center_x = screen_width / 2
+screen_center_y = screen_height / 2
+
+screen = MockRect(
+    0,
+    screen_height,
+    0,
+    screen_width)
+
+# The player is in the center of the screen
+base_player = MockRect(
+    screen_center_y - 10,
+    screen_center_y + 10,
+    screen_center_x - 10,
+    screen_center_x + 10)
+
+class TestAdjustX(TestCase):
+    def test_does_nothing_if_player_in_the_center(self):
+        camera = Camera()
+        camera.adjust_x(screen, base_player)
+        self.assertEqual(camera.x, 0)
+
+    def test_increases_x_if_player_on_the_right(self):
+        camera = Camera()
+        player = shifted(base_player, x_shift=screen_width)
+        camera.adjust_x(screen, player)
+        self.assertGreater(camera.x, 0)
+
+    def test_decreases_x_if_player_on_the_left(self):
+        camera = Camera()
+        player = shifted(base_player, x_shift=-screen_width)
+        camera.adjust_x(screen, player)
+        self.assertLess(camera.x, 0)
+
+class TestAdjustY(TestCase):
+    def test_does_nothing_if_player_in_the_center(self):
+        camera = Camera()
+        camera.adjust_y(screen, base_player)
+        self.assertEqual(camera.y, 0)
+
+    def test_increases_y_if_player_on_the_bottom(self):
+        camera = Camera()
+        player = shifted(base_player, y_shift=screen_height)
+        camera.adjust_y(screen, player)
+        self.assertGreater(camera.y, 0)
+
+    def test_decreases_y_if_player_on_the_top(self):
+        camera = Camera()
+        player = shifted(base_player, y_shift=-screen_height)
+        camera.adjust_y(screen, player)
+        self.assertLess(camera.y, 0)

--- a/tests/test_obstacle.py
+++ b/tests/test_obstacle.py
@@ -4,48 +4,8 @@ from unittest import TestCase
 from skater.obstacles import Obstacle
 from skater import images
 
-class MockRect:
-    """
-    A mock replacement of `pygame.sprite.Sprite.rect` for testing purposes
-    """
-    def __init__(self, top, bottom, left, right):
-        self.top = top
-        self.bottom = bottom
-        self.left = left
-        self.right = right
+from .mock_rect import shifted, makeMockRect
 
-    @property
-    def x(self):
-        return self.left
-
-    @property 
-    def y(self):
-        return self.top
-
-    @property
-    def width(self):
-        return (self.right - self.left)
-
-    @property
-    def height(self):
-        return (self.bottom - self.top)
-
-# Utility methods to make tests more readable
-def makeMockRect(other_rectangle):
-    return MockRect(
-        other_rectangle.top,
-        other_rectangle.bottom,
-        other_rectangle.left,
-        other_rectangle.right
-    )
-
-def shifted(base_rect, x_shift=0, y_shift=0):
-    return MockRect(
-        base_rect.top + y_shift,
-        base_rect.bottom + y_shift,
-        base_rect.left + x_shift,
-        base_rect.right + x_shift
-    )
 
 class TestObstacle(TestCase):
     """


### PR DESCRIPTION
Dodałem to o czym wspominałem w komentarzach - pozycja gracza / planszy jest teraz niezależna od ruchu kamery. Kamera decyduje gdzie wyrenderować obiekty, ale nie zmienia ich pozycji:
- wcześniej jeśli gracz znajdował się na pozycji np. `x=1000` a ekran miał tylko 500 pikseli szerokości, modyfikowaliśmy wartość `player.rect.x` żeby ją wyrenderować na ekranie
- w tym momencie jeśli gracz jest na pozycji `x=1000`, nie będziemy tej wartości modyfikować przy renderowaniu -> zamiast tego powiemy rendererowi żeby podmienił pozycję renderowania na podstawie wartości `Camera.x`

Odkomentowałem też pani kod do ruchu kamery z lagiem - teraz działa ok.

closes #12 